### PR TITLE
Force use of winston 2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Lambda to send cloudwatch logs to papertrail",
   "main": "index.js",
   "dependencies": {
-    "winston": "",
+    "winston": "2.x",
     "winston-papertrail": "hyrwork/winston-papertrail",
     "dogapi": ""
   },


### PR DESCRIPTION
The code here is built on the Winston 2.x library.  If you don't explicitly define that, it tries to use 3.x and breaks.